### PR TITLE
fix: raise text contrast under glowing elements

### DIFF
--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -19,7 +19,7 @@ import { resume } from "../data/resume";
           <svg xmlns="http://www.w3.org/2000/svg" style="width:20px;height:20px;color:#00F5FF;" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
         </div>
         <h3 class="font-heading font-semibold mb-1" style="color:#DDEEFF;">Email</h3>
-        <p class="text-sm" style="color:#252540;">{resume.email}</p>
+        <p class="text-sm" style="color:#8899AA;">{resume.email}</p>
       </a>
 
       <a href={`tel:${resume.phone}`} class="group bg-surface-light rounded-xl p-6 border transition-all text-center" style="border-color:rgba(255,255,255,0.06);text-decoration:none;" onmouseenter="this.style.borderColor='rgba(0,245,255,0.2)';this.style.boxShadow='0 0 20px rgba(0,245,255,0.06)'" onmouseleave="this.style.borderColor='rgba(255,255,255,0.06)';this.style.boxShadow='none'">
@@ -27,7 +27,7 @@ import { resume } from "../data/resume";
           <svg xmlns="http://www.w3.org/2000/svg" style="width:20px;height:20px;color:#00F5FF;" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg>
         </div>
         <h3 class="font-heading font-semibold mb-1" style="color:#DDEEFF;">Phone</h3>
-        <p class="text-sm" style="color:#252540;">{resume.phone}</p>
+        <p class="text-sm" style="color:#8899AA;">{resume.phone}</p>
       </a>
 
       <a href={resume.linkedin} target="_blank" rel="noopener" class="group bg-surface-light rounded-xl p-6 border transition-all text-center" style="border-color:rgba(255,255,255,0.06);text-decoration:none;" onmouseenter="this.style.borderColor='rgba(0,245,255,0.2)';this.style.boxShadow='0 0 20px rgba(0,245,255,0.06)'" onmouseleave="this.style.borderColor='rgba(255,255,255,0.06)';this.style.boxShadow='none'">
@@ -35,7 +35,7 @@ import { resume } from "../data/resume";
           <svg xmlns="http://www.w3.org/2000/svg" style="width:20px;height:20px;color:#00F5FF;" viewBox="0 0 24 24" fill="currentColor"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
         </div>
         <h3 class="font-heading font-semibold mb-1" style="color:#DDEEFF;">LinkedIn</h3>
-        <p class="text-sm" style="color:#252540;">{resume.location}</p>
+        <p class="text-sm" style="color:#8899AA;">{resume.location}</p>
       </a>
     </div>
   </div>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -42,7 +42,7 @@ const kpiColors = [
       </h1>
 
       <!-- Role line -->
-      <p class="reveal" style="animation-delay:150ms;font-family:'JetBrains Mono',monospace;font-size:10px;color:#252540;letter-spacing:0.5px;margin-bottom:20px;">
+      <p class="reveal" style="animation-delay:150ms;font-family:'JetBrains Mono',monospace;font-size:10px;color:#5A5A80;letter-spacing:0.5px;margin-bottom:20px;">
         {resume.stats[0].value}{resume.stats[0].suffix} experience · AWS · Snowflake · Databricks · Lakehouse
       </p>
 
@@ -105,7 +105,7 @@ const kpiColors = [
           >
             0
           </div>
-          <div style="font-family:'JetBrains Mono',monospace;font-size:8px;letter-spacing:1.5px;text-transform:uppercase;margin-top:3px;color:#252540;">
+          <div style="font-family:'JetBrains Mono',monospace;font-size:8px;letter-spacing:1.5px;text-transform:uppercase;margin-top:3px;color:#8899AA;">
             {stat.label}
           </div>
           <div style={`height:2px;border-radius:1px;margin-top:10px;background:linear-gradient(90deg,rgb(${kpiColors[i].rgb}),transparent);box-shadow:0 0 5px rgba(${kpiColors[i].rgb},0.4);`} />

--- a/src/components/Projects.astro
+++ b/src/components/Projects.astro
@@ -69,7 +69,7 @@ import { resume } from "../data/resume";
     btn.addEventListener("click", () => {
       buttons.forEach((b) => {
         b.className = "filter-btn px-4 py-2 text-sm font-medium rounded-lg border transition-all duration-300 bg-transparent border-border";
-        b.style.cssText = "font-family:'JetBrains Mono',monospace;font-size:11px;color:#445566;";
+        b.style.cssText = "font-family:'JetBrains Mono',monospace;font-size:11px;color:#667788;";
       });
       btn.className = "filter-btn px-4 py-2 text-sm font-medium rounded-lg border transition-all duration-300";
       btn.style.cssText = "font-family:'JetBrains Mono',monospace;font-size:11px;background:#AA66FF;color:#000;border-color:#AA66FF;";

--- a/src/components/SkillsRadar.astro
+++ b/src/components/SkillsRadar.astro
@@ -100,10 +100,10 @@ const radarData = computeRadarData();
           r: {
             beginAtZero: true,
             max: 5,
-            ticks: { stepSize: 1, color: "#252540", backdropColor: "transparent" },
+            ticks: { stepSize: 1, color: "#5A5A80", backdropColor: "transparent" },
             grid: { color: "rgba(170,255,0,0.07)" },
             angleLines: { color: "rgba(170,255,0,0.07)" },
-            pointLabels: { color: "#445566", font: { family: "'JetBrains Mono', monospace", size: 11 } },
+            pointLabels: { color: "#8899AA", font: { family: "'JetBrains Mono', monospace", size: 11 } },
           },
         },
         plugins: {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -36,8 +36,8 @@
 
   /* Text */
   --color-text:         #DDEEFF;
-  --color-text-muted:   #445566;
-  --color-text-dim:     #252540;
+  --color-text-muted:   #8899AA;
+  --color-text-dim:     #5A5A80;
   --color-heading:      #DDEEFF;
 
   /* Borders */


### PR DESCRIPTION
## Summary

- `--color-text-muted` lifted from `#445566` → `#8899AA` (~6:1 contrast ratio): fixes body text in About, Experience, Projects, Education
- `--color-text-dim` lifted from `#252540` → `#5A5A80`: fixes metadata text (location, period) in Experience and Education
- Hero KPI pill labels (directly under glowing numbers) changed from near-invisible `#252540` → `#8899AA`
- Hero role line changed from `#252540` → `#5A5A80`
- Contact section email/phone/location values changed from `#252540` → `#8899AA`
- Chart.js radar chart tick marks and axis labels lifted to match new scale
- Projects inactive filter button text lifted from `#445566` → `#667788`

Intentionally dim decorative elements (`//` code comment in Hero, inactive social icon fill) left unchanged — they carry no readable content.

## Test plan
- [x] `npm run build` passes
- [x] All 15 Playwright tests pass